### PR TITLE
add eslint and prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,61 @@
+{
+	"root": true,
+	"env": {
+		"browser": true,
+		"jest": true,
+		"node": true
+	},
+	"extends": ["eslint:recommended", "plugin:prettier/recommended"],
+	"globals": {
+		"document": true,
+		"fetch": true,
+		"FormData": true,
+		"Headers": true,
+		"window": true,
+		"wp": true,
+		"wpApiSettings": true,
+		"jQuery": true,
+		"getUserSetting": true,
+		"switchEditors": true,
+		"setUserSetting": true,
+		"Promise": true
+	},
+	"ignorePatterns": [
+		"*-min.js"
+	],
+	"parserOptions": {
+		"ecmaVersion": 2018,
+		"sourceType": "module",
+		"ecmaFeatures": {
+			"jsx": true
+		}
+	},
+	"rules": {
+		"func-style": [
+			"error",
+			"expression",
+			{
+				"allowArrowFunctions": true
+			}
+		],
+		"no-console": [
+			"error",
+			{
+				"allow": ["warn", "error"]
+			}
+		],
+		"no-unused-vars": "error",
+		"no-var": "error",
+		"prefer-arrow-callback": "error",
+		"prefer-const": "error",
+		"react/no-unescaped-entities": "off",
+		"react/react-in-jsx-scope": "off",
+		"max-len": ["error", { "code": 9999 }],
+		"computed-property-spacing": 0
+	},
+	"settings": {
+		"react": {
+			"version": "detect"
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,13 @@
   "devDependencies": {
     "@wordpress/env": "^5.7",
     "jsdoc": "~3.6.3",
-    "wp-hookdoc": "^0.2.0"
+    "wp-hookdoc": "^0.2.0",
+    "eslint": "^7.25.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "husky": "^6.0.0",
+    "lint-staged": "^10.5.4",
+    "prettier": "^2.8.4"
   },
   "scripts": {
     "build:docs": "rm -rf docs/ && jsdoc -c hookdoc-conf.json",
@@ -30,6 +36,8 @@
     "lint-php": "wp-env run composer run-script lint",
     "pretest-php": "wp-env run composer 'install --no-interaction'",
     "test-php": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/conference/phpunit.xml.dist --verbose'",
+    "lint-js": "eslint --fix './src/assets/js'",
     "wp-env": "wp-env"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.9 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description
<!-- Please describe your changes -->
This adds ESLint and Prettier via package.json and includes an eslint config.

This also includes husky and lint-staged which can be configured to scan committed files to ensure commits are linted.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I rant the command `nvm use && npm i && npm run lint-js` to install and then lint the JS files.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Dev package only, no functional updates.

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [x] My code follows the WordPress coding standards.
- [x] My code has proper inline documentation.
